### PR TITLE
re #18096 - Updates to EMG.Extensions.Logging.Loggly to avoid Mapping…

### DIFF
--- a/src/Logging/Loggly/Loggly/LogglyHttpClient.cs
+++ b/src/Logging/Loggly/Loggly/LogglyHttpClient.cs
@@ -103,7 +103,7 @@ namespace EMG.Extensions.Logging.Loggly
                 Category = logglyMessage.Category,
                 Data = newData,
                 Error = logglyMessage.Error,
-                Event = logglyMessage.Event,
+                EventId = logglyMessage.EventId,
                 Level = logglyMessage.Level,
                 MachineName = logglyMessage.MachineName,
                 Message = logglyMessage.Message

--- a/src/Logging/Loggly/Loggly/LogglyLogger.cs
+++ b/src/Logging/Loggly/Loggly/LogglyLogger.cs
@@ -47,7 +47,7 @@ namespace EMG.Extensions.Logging.Loggly
                 MachineName = Environment.MachineName,
                 Category = Name,
                 Data = state,
-                Event = eventId,
+                EventId = eventId,
                 Message = message,
                 Level = logLevel,
                 Error = FormatException(exception)

--- a/src/Logging/Loggly/Loggly/LogglyMessage.cs
+++ b/src/Logging/Loggly/Loggly/LogglyMessage.cs
@@ -13,7 +13,7 @@ namespace EMG.Extensions.Logging.Loggly
 
         public string Category { get; set; }
 
-        public EventId Event { get; set; }
+        public EventId EventId { get; set; }
 
         public string Message { get; set; }
 

--- a/tests/Logging/Tests.Loggly/Loggly/LogglyLoggerTests.cs
+++ b/tests/Logging/Tests.Loggly/Loggly/LogglyLoggerTests.cs
@@ -60,7 +60,7 @@ namespace Tests.Loggly
 
             sut.Log(level, eventId, state, error, formatter);
 
-            Mock.Get(processor).Verify(p => p.EnqueueMessage(It.Is<LogglyMessage>(m => m.Level == level && m.Category == sut.Name && m.Event == eventId && m.Data == state && m.Message == message)));
+            Mock.Get(processor).Verify(p => p.EnqueueMessage(It.Is<LogglyMessage>(m => m.Level == level && m.Category == sut.Name && m.EventId == eventId && m.Data == state && m.Message == message)));
         }
 
         [Test, AutoMoqData]


### PR DESCRIPTION
…Conflict with Nybus v0

- changing naming Event to EventId, since it's breaking Loggly