### PR TITLE
re #18483 - Making the EMG.Extensions.Logging.Loggly awaitable 

### DIFF
--- a/src/Logging/Loggly/Loggly/LogglyMessage.cs
+++ b/src/Logging/Loggly/Loggly/LogglyMessage.cs
@@ -23,6 +23,8 @@ namespace EMG.Extensions.Logging.Loggly
         public LogLevel Level { get; set; }
 
         public Error Error { get; set; }
+
+        public static LogglyMessage Default => new LogglyMessage {Level = LogLevel.Trace};
     }
 
     public class Error

--- a/src/Logging/Loggly/Loggly/LogglyOptions.cs
+++ b/src/Logging/Loggly/Loggly/LogglyOptions.cs
@@ -26,6 +26,8 @@ namespace EMG.Extensions.Logging.Loggly
         public Action<LogglyMessage> PreProcessMessage { get; set; }
 
         public Encoding ContentEncoding { get; set; } = Encoding.UTF8;
+
+        public TimeSpan Buffer { get; set; } = TimeSpan.FromMilliseconds(50);
     }
 
     public delegate bool FilterDelegate(string categoryName, EventId eventId, LogLevel logLevel);

--- a/src/Logging/Loggly/Loggly/LogglyProcessor.cs
+++ b/src/Logging/Loggly/Loggly/LogglyProcessor.cs
@@ -22,7 +22,7 @@ namespace EMG.Extensions.Logging.Loggly
         public LogglyProcessor(ILogglyClient client, LogglyOptions options)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
-            _ = options?.Buffer ?? throw new ArgumentNullException(nameof(options.Buffer));
+            _ = options ?? throw new ArgumentNullException(nameof(options));
 
             var closing = _messageSubject.Buffer(options.Buffer).Select(i => LogglyMessage.Default).Merge(_flush);
             _subscription = _messageSubject.Buffer(() => closing).Subscribe(ProcessLogQueue);

--- a/src/Logging/Loggly/Loggly/LogglyProcessor.cs
+++ b/src/Logging/Loggly/Loggly/LogglyProcessor.cs
@@ -19,11 +19,12 @@ namespace EMG.Extensions.Logging.Loggly
         private readonly ISubject<LogglyMessage> _flush = new Subject<LogglyMessage>();
         private readonly IDisposable _subscription;
 
-        public LogglyProcessor(ILogglyClient client)
+        public LogglyProcessor(ILogglyClient client, LogglyOptions options)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
+            _ = options?.Buffer ?? throw new ArgumentNullException(nameof(options.Buffer));
 
-            var closing = _messageSubject.Buffer(TimeSpan.FromMilliseconds(50)).Select(i => LogglyMessage.Default).Merge(_flush);
+            var closing = _messageSubject.Buffer(options.Buffer).Select(i => LogglyMessage.Default).Merge(_flush);
             _subscription = _messageSubject.Buffer(() => closing).Subscribe(ProcessLogQueue);
         }
 

--- a/tests/Logging/Tests.Loggly/Loggly/LogglyProcessorTests.cs
+++ b/tests/Logging/Tests.Loggly/Loggly/LogglyProcessorTests.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using AutoFixture;
 using AutoFixture.Idioms;
 using AutoFixture.NUnit3;
 using EMG.Extensions.Logging.Loggly;
@@ -21,8 +22,10 @@ namespace Tests.Loggly
         }
 
         [Test, AutoMoqData]
-        public async Task Message_is_published_after_adding_to_queue_with_delay([Frozen] ILogglyClient client, LogglyProcessor sut, LogglyMessage message)
+        public async Task Message_is_published_after_adding_to_queue_with_delay([Frozen] ILogglyClient client, LogglyMessage message, IFixture fixture)
         {
+            var sut = CreateSut(fixture, client, 50);
+
             sut.EnqueueMessage(message);
 
             await Task.Delay(TimeSpan.FromMilliseconds(100));
@@ -37,25 +40,36 @@ namespace Tests.Loggly
 
             sut.EnqueueMessage(message);
 
-            Mock.Get(client).Verify(p => p.PublishAsync(message), Times.Never);
+            Mock.Get(client).Verify(p => p.PublishManyAsync(It.Is<IEnumerable<LogglyMessage>>(m => m.Contains(message))), Times.Never);
         }
 
         [Test, AutoMoqData]
-        public async Task Message_is_not_published_after_adding_to_queue_without_delay([Frozen] ILogglyClient client, LogglyProcessor sut, LogglyMessage message)
+        public async Task Message_is_not_published_after_adding_to_queue_without_delay([Frozen] ILogglyClient client, LogglyMessage message, IFixture fixture)
         {
+            var sut = CreateSut(fixture, client, 1000);
+
             sut.EnqueueMessage(message);
 
             Mock.Get(client).Verify(p => p.PublishManyAsync(It.Is<IEnumerable<LogglyMessage>>(m => m.Contains(message))), Times.Never);
         }
 
         [Test, AutoMoqData]
-        public async Task Message_is_published_after_adding_to_queue_without_delay_after_flush([Frozen] ILogglyClient client, LogglyProcessor sut, LogglyMessage message)
+        public async Task Message_is_published_after_adding_to_queue_without_delay_after_flush([Frozen] ILogglyClient client, LogglyMessage message, IFixture fixture)
         {
+            var sut = CreateSut(fixture, client, 1000);
+
             sut.EnqueueMessage(message);
 
             sut.FlushMessages();
 
             Mock.Get(client).Verify(p => p.PublishManyAsync(It.Is<IEnumerable<LogglyMessage>>(m => m.Contains(message))), Times.Once);
+        }
+
+        private LogglyProcessor CreateSut(IFixture fixture, ILogglyClient client, int buffer)
+        {
+            var options = fixture.Build<LogglyOptions>().With(i => i.Buffer, TimeSpan.FromMilliseconds(buffer))
+                .Create();
+            return new LogglyProcessor(client, options);
         }
     }
 }

--- a/tests/Logging/Tests.Loggly/Loggly/LogglyProcessorTests.cs
+++ b/tests/Logging/Tests.Loggly/Loggly/LogglyProcessorTests.cs
@@ -21,7 +21,7 @@ namespace Tests.Loggly
         }
 
         [Test, AutoMoqData]
-        public async Task Message_is_published_after_adding_to_queue([Frozen] ILogglyClient client, LogglyProcessor sut, LogglyMessage message)
+        public async Task Message_is_published_after_adding_to_queue_with_delay([Frozen] ILogglyClient client, LogglyProcessor sut, LogglyMessage message)
         {
             sut.EnqueueMessage(message);
 
@@ -38,6 +38,24 @@ namespace Tests.Loggly
             sut.EnqueueMessage(message);
 
             Mock.Get(client).Verify(p => p.PublishAsync(message), Times.Never);
+        }
+
+        [Test, AutoMoqData]
+        public async Task Message_is_not_published_after_adding_to_queue_without_delay([Frozen] ILogglyClient client, LogglyProcessor sut, LogglyMessage message)
+        {
+            sut.EnqueueMessage(message);
+
+            Mock.Get(client).Verify(p => p.PublishManyAsync(It.Is<IEnumerable<LogglyMessage>>(m => m.Contains(message))), Times.Never);
+        }
+
+        [Test, AutoMoqData]
+        public async Task Message_is_published_after_adding_to_queue_without_delay_after_flush([Frozen] ILogglyClient client, LogglyProcessor sut, LogglyMessage message)
+        {
+            sut.EnqueueMessage(message);
+
+            sut.FlushMessages();
+
+            Mock.Get(client).Verify(p => p.PublishManyAsync(It.Is<IEnumerable<LogglyMessage>>(m => m.Contains(message))), Times.Once);
         }
     }
 }


### PR DESCRIPTION
Added possibility to flush the messages in the logglyprocessor instead of having to wait for the buffer