### PR TITLE
COREX-1392 migrate static images

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -12,7 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/emgdev/dotnet-extensions</PackageProjectUrl>
-    <PackageIconUrl>http://static.emg-services.net/masterpages/pics/logos/emg-icon-64.png</PackageIconUrl>
+    <PackageIconUrl>https://cdn-static.emg-services.net/masterpages/pics/logos/emg-icon-64.png</PackageIconUrl>
     <NoWarn>NU5105,NU5125</NoWarn>
   </PropertyGroup>
 


### PR DESCRIPTION
Moved package icon to bucket emg-static (see ticket https://keystoneedugroup.atlassian.net/browse/COREX-1392?focusedCommentId=146880)